### PR TITLE
specify networkx to use version 2.1.0 in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__
 /docs/descriptors.rst
 /docs/atomic_prop.rst
 build/
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-install_requires = ["six==1.*", "numpy==1.*", "networkx==2.*"]
+install_requires = ["six==1.*", "numpy==1.*", "networkx==2.1.0"]
 
 if sys.version_info < (3, 4, 0):
     install_requires.append("enum34")


### PR DESCRIPTION
mordred installs the newest version of networkx(2.4.0, as for today). But `biconnected_component_subgraphs` is already depracated in networkx (>2.1.0).
closes #84

Issue #
