### PR TITLE
Changed Update to Write

### DIFF
--- a/mordred/_util.py
+++ b/mordred/_util.py
@@ -75,7 +75,7 @@ class NotebookWrapper(object):
         self.bar.update(*args, **kwargs)
 
     def write(self, *args, **kwargs):
-        self.bar.update(*args, **kwargs)
+        self.bar.write(*args, **kwargs)
 
 
 def PathType(string):


### PR DESCRIPTION
Update function in tqdm accepts only integer arguments, and the write function should be used to output errors in the console. This causes errors when using tqdm and an error occurs and is printed to console.